### PR TITLE
Stop mobile browser double scroll

### DIFF
--- a/portal/src/assets/base.css
+++ b/portal/src/assets/base.css
@@ -41,8 +41,12 @@
   left: 0px;
   z-index: -1;
 }
+
+/* fix double scrolling caused by mobile browser nav/url bars */
+html {
+  overflow: hidden;
+}
 body {
-  min-height: 100vh;
   transition:
     color 0.5s,
     background-color 0.5s;


### PR DESCRIPTION
This fixes the accidental ability to scroll the main page due to navbars etc on mobile causing 100vw to not be quite right.

I've not been able to test this with actual captions, but in dev tools i've checked there seems to be enough space on a tiny iPhone SE screen.